### PR TITLE
lorne/review-all-page

### DIFF
--- a/views/dashboard.handlebars
+++ b/views/dashboard.handlebars
@@ -4,8 +4,7 @@
         <!--Still not working--> 
     <h2> Welcome {{user.name}}</h2>
     <div id="todayDeck">
-    <h2>Today's Deck:</h2>
-    <button id="todaysDeck"><a href="/review">Start</a></button>
+    <button id="todaysDeck"><a href="/review/all">Review all Cards</a></button>
     </div>
     <button id="createDeck"><a href="/create">Create Deck</a></button>
 </div>


### PR DESCRIPTION
## Review all cards in queue across all decks.
* tweaked the review cards api endpoint so it would handle `all` as an id/argument. `localhost:3001/review/all` will now take the user to a view that allows them to rate all cards in their queue.
* Updated button in dashboard to say `Review all Cards`
